### PR TITLE
Exit with code 1 on failure

### DIFF
--- a/src/ConsoleCommand.php
+++ b/src/ConsoleCommand.php
@@ -117,6 +117,7 @@ abstract class ConsoleCommand extends Command
                 $output->writeln('Doing: ' . $command . " to " . $version);
             });
         }
+        return 0;
     }
 
     /**

--- a/src/CreateCommand.php
+++ b/src/CreateCommand.php
@@ -79,5 +79,6 @@ class CreateCommand extends Command
             $output->writeln('Created UP version: ' . $this->createMigrationSql("$path/migrations/up", 0));
             $output->writeln('Created DOWN version: ' . $this->createMigrationSql("$path/migrations/down", -1));
         }
+        return 0;
     }
 }

--- a/src/DatabaseVersionCommand.php
+++ b/src/DatabaseVersionCommand.php
@@ -24,8 +24,10 @@ class DatabaseVersionCommand extends ConsoleCommand
             $versionInfo = $this->migration->getCurrentVersion();
             $output->writeln('version: ' . $versionInfo['version']);
             $output->writeln('status.: ' . $versionInfo['status']);
+            return 0;
         } catch (Exception $ex) {
             $this->handleError($ex, $output);
+            return 1;
         }
     }
 }

--- a/src/DatabaseVersionCommand.php
+++ b/src/DatabaseVersionCommand.php
@@ -19,15 +19,16 @@ class DatabaseVersionCommand extends ConsoleCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        parent::execute($input, $output);
         try {
-            $versionInfo = $this->migration->getCurrentVersion();
-            $output->writeln('version: ' . $versionInfo['version']);
-            $output->writeln('status.: ' . $versionInfo['status']);
-            return 0;
+            if (parent::execute($input, $output) == 0) {
+                $versionInfo = $this->migration->getCurrentVersion();
+                $output->writeln('version: ' . $versionInfo['version']);
+                $output->writeln('status.: ' . $versionInfo['status']);
+                return 0;
+            }
         } catch (Exception $ex) {
             $this->handleError($ex, $output);
-            return 1;
         }
+        return 1;
     }
 }

--- a/src/DownCommand.php
+++ b/src/DownCommand.php
@@ -38,8 +38,10 @@ class DownCommand extends ConsoleCommand
 
             parent::execute($input, $output);
             $this->migration->down($this->upTo, true);
+            return 0;
         } catch (Exception $ex) {
             $this->handleError($ex, $output);
+            return 1;
         }
     }
 }

--- a/src/DownCommand.php
+++ b/src/DownCommand.php
@@ -32,16 +32,17 @@ class DownCommand extends ConsoleCommand
                 if (!$helper->ask($input, $output, $question)) {
                     $output->writeln('Aborted.');
 
-                    return;
+                    return 1;
                 }
             }
 
-            parent::execute($input, $output);
-            $this->migration->down($this->upTo, true);
-            return 0;
+            if (parent::execute($input, $output) == 0) {
+                $this->migration->down($this->upTo, true);
+                return 0;
+            }
         } catch (Exception $ex) {
             $this->handleError($ex, $output);
-            return 1;
         }
+        return 1;
     }
 }

--- a/src/InstallCommand.php
+++ b/src/InstallCommand.php
@@ -44,8 +44,10 @@ class InstallCommand extends ConsoleCommand
             $output->writeln($action);
             $output->writeln('current version: ' . $version['version']);
             $output->writeln('current status.: ' . $version['status']);
+            return 0;
         } catch (Exception $ex) {
             $this->handleError($ex, $output);
+            return 1;
         }
     }
 }

--- a/src/InstallCommand.php
+++ b/src/InstallCommand.php
@@ -27,7 +27,9 @@ class InstallCommand extends ConsoleCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            parent::execute($input, $output);
+            if (parent::execute($input, $output) != 0) {
+                return 1;
+            };
 
             $action = 'Database is already versioned. ';
             try {

--- a/src/ResetCommand.php
+++ b/src/ResetCommand.php
@@ -55,8 +55,10 @@ class ResetCommand extends ConsoleCommand
             parent::execute($input, $output);
             $this->migration->prepareEnvironment();
             $this->migration->reset($this->upTo);
+            return 0;
         } catch (Exception $ex) {
             $this->handleError($ex, $output);
+            return 1;
         }
     }
 }

--- a/src/ResetCommand.php
+++ b/src/ResetCommand.php
@@ -48,17 +48,18 @@ class ResetCommand extends ConsoleCommand
                 if (!$helper->ask($input, $output, $question)) {
                     $output->writeln('Aborted.');
 
-                    return;
+                    return 1;
                 }
             }
 
-            parent::execute($input, $output);
-            $this->migration->prepareEnvironment();
-            $this->migration->reset($this->upTo);
-            return 0;
+            if (parent::execute($input, $output) == 0) {
+                $this->migration->prepareEnvironment();
+                $this->migration->reset($this->upTo);
+                return 0;
+            }
         } catch (Exception $ex) {
             $this->handleError($ex, $output);
-            return 1;
         }
+        return 1;
     }
 }

--- a/src/UpdateCommandBase.php
+++ b/src/UpdateCommandBase.php
@@ -25,16 +25,17 @@ abstract class UpdateCommandBase extends ConsoleCommand
                 if (!$helper->ask($input, $output, $question)) {
                     $output->writeln('Aborted.');
 
-                    return;
+                    return 1;
                 }
             }
 
-            parent::execute($input, $output);
-            $this->callMigrate();
-            return 0;
+            if (parent::execute($input, $output) == 0) {
+                $this->callMigrate();
+                return 0;
+            }
         } catch (Exception $ex) {
             $this->handleError($ex, $output);
-            return 1;
         }
+        return 1;
     }
 }

--- a/src/UpdateCommandBase.php
+++ b/src/UpdateCommandBase.php
@@ -31,8 +31,10 @@ abstract class UpdateCommandBase extends ConsoleCommand
 
             parent::execute($input, $output);
             $this->callMigrate();
+            return 0;
         } catch (Exception $ex) {
             $this->handleError($ex, $output);
+            return 1;
         }
     }
 }


### PR DESCRIPTION
Getting an error code on failure is pretty important when running migrations from a script.
For example, I would like to apply migrations in an init script in the official postgresql docker image in our CI, and also want to automate it in our deploy scripts. In both of these use-cases detecting that the migration failed is necessary.